### PR TITLE
PAP5500 DUO: enable display backlight

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 |                                      | JTY D101                                        | Lenovo A369i                | Energy Phone Colors           | Prestigio PAP5500 DUO                           |
 |--------------------------------------|-------------------------------------------------|-----------------------------|-------------------------------|-------------------------------------------------|
 | DRM                                  | 🟢 OK, needs panel improvements (power up/down) | 🟢 OK, needs sane panel     | 🟡 partial: needs panel fixes | 🟢 OK, needs panel improvements (power up/down) |
-| display brightness                   | 🔴 DEAD                                         | 🔴 DEAD                     | 🔴 DEAD                       | 🔴 DEAD                                         |
+| display brightness                   | 🔴 DEAD                                         | 🔴 DEAD                     | 🔴 DEAD                       | 🟢 OK: pwm-backlight on mt6572 PWM2             |
 | vol +/- keys: mediatek,mt6779-keypad | 🟢 OK                                           | 🔴 TBD                      | 🔴 TBD                        | 🟢 OK                                           |
 | power key: mediatek,mt6323-keys      | 🟢 OK                                           | 🟢 OK                       | 🔴 TBD                        | 🟢 OK                                           |
 | haptics: regulator-haptic            | 🟢 OK                                           | 🔴 TBD                      | 🔴 TBD                        | 🟢 OK                                           |

--- a/arch/arm/boot/dts/mediatek/mt6572-prestigio-pap5500-duo.dts
+++ b/arch/arm/boot/dts/mediatek/mt6572-prestigio-pap5500-duo.dts
@@ -62,6 +62,13 @@
 		min-microvolt = <1200000>;
 		max-microvolt = <3300000>;
 	};
+
+	backlight: backlight {
+		compatible = "pwm-backlight";
+		pwms = <&pwm 1 31250>;
+		default-brightness-level = <128>;
+		power-supply = <&mt6323_vsys_reg>;
+	};
 };
 
 &auxadc {
@@ -81,6 +88,7 @@
 		compatible = "boyi,otm8018b";
 		reg = <0>;
 		vcc-supply = <&mt6323_vgp1_reg>;
+		backlight = <&backlight>;
 
 		port {
 			panel_in: endpoint {
@@ -177,6 +185,12 @@
 	regulator-boot-on;
 };
 
+&pwm {
+	pinctrl-0 = <&bl_pwm_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
 &uart0 {
 	status = "okay";
 };
@@ -238,6 +252,12 @@
 };
 
 &pio {
+	bl_pwm_pins: bl-pwm-pins {
+		pins {
+			pinmux = <MT6572_PIN_30_LPD16__FUNC_PWM2>;
+		};
+	};
+
 	pmic_int_pins: pmic-int-pins {
 		pins {
 			pinmux = <MT6572_PIN_7_PMIC_EINT__FUNC_PMIC_EINT>;

--- a/arch/arm/boot/dts/mediatek/mt6572.dtsi
+++ b/arch/arm/boot/dts/mediatek/mt6572.dtsi
@@ -461,6 +461,19 @@
 			status = "disabled";
 		};
 
+		pwm: pwm@11008000 {
+			compatible = "mediatek,mt7623-pwm";
+			reg = <0x11008000 0x1000>;
+			#pwm-cells = <2>;
+			clocks = <&topckgen CLK_TOP_PWM>, <&topckgen CLK_TOP_PWM>,
+				 <&topckgen CLK_TOP_PWM>, <&topckgen CLK_TOP_PWM>,
+				 <&topckgen CLK_TOP_PWM>, <&topckgen CLK_TOP_PWM>,
+				 <&topckgen CLK_TOP_PWM>;
+			clock-names = "top", "main",
+				      "pwm1", "pwm2", "pwm3", "pwm4", "pwm5";
+			status = "disabled";
+		};
+
 		usb: usb@11100000 {
 			compatible = "mediatek,mt2701-musb",
 				     "mediatek,mtk-musb";

--- a/drivers/gpu/drm/panel/panel-orisetech-otm8018b.c
+++ b/drivers/gpu/drm/panel/panel-orisetech-otm8018b.c
@@ -179,6 +179,10 @@ static int otm8018b_probe(struct mipi_dsi_device *dsi)
 	dsi->format = MIPI_DSI_FMT_RGB888;
 	dsi->mode_flags = ctx->desc->mode_flags;
 
+	ret = drm_panel_of_backlight(&ctx->panel);
+	if (ret)
+		return dev_err_probe(dev, ret, "failed to get backlight\n");
+
 	drm_panel_add(&ctx->panel);
 
 	ret = mipi_dsi_attach(dsi);


### PR DESCRIPTION
## Summary
- Add MT6572 generic PWM controller node (`pwm@11008000`, `mediatek,mt7623-pwm` compatible).
- `drm/panel: orisetech-otm8018b`: look up the panel backlight with `drm_panel_of_backlight()` so the DRM core gates it with panel power state.
- `ARM: dts: pap5500-duo`: enable `&pwm`, add `pwm-backlight` on channel 1 at 32 kHz, mux pin 30 to `PWM2`, reference the backlight from the panel node. Linear curve (`duty = level/4`) matching stock; any perceptual curve is left to userspace.
- README: flip "display brightness" to OK for PAP5500 DUO.

## Commits
1. `drm/panel: orisetech-otm8018b: get backlight`
2. `ARM: dts: mediatek: mt6572: add PWM controller`
3. `ARM: dts: mediatek: pap5500-duo: add display backlight`
4. `README: mark display brightness OK on Prestigio PAP5500 DUO`

## Test plan
- [x] `/sys/class/backlight/backlight` appears with `max_brightness`, `brightness`, `bl_power`.
- [x] Writing `brightness` 0..max physically dims/brightens the panel on PAP5500 DUO hardware.
- [x] Panel power state and backlight are gated together via DRM prepare/unprepare.
- [x] `CONFIG_PWM_MEDIATEK=y` + `CONFIG_BACKLIGHT_PWM=y`.

https://github.com/user-attachments/assets/ebd159d3-908e-4180-9988-f990ed2b9c6e

used following script to validate brightness change: 
[S99-pap5500-test.zip](https://github.com/user-attachments/files/28395012/S99-pap5500-test.zip)
